### PR TITLE
fixup kentik-specific sedutil patches

### DIFF
--- a/Contrib/sed-opal.service
+++ b/Contrib/sed-opal.service
@@ -17,7 +17,9 @@ RequiresMountsFor=/tmp
 Type=oneshot
 TimeoutSec=600
 RemainAfterExit=yes
-ExecStart=/bin/sh -c "/usr/sbin/dmidecode -s system-serial-number | /bin/egrep -v '^#' | /usr/sbin/linuxpba 2>/tmp/linuxpba.debug"
+ExecStart=/bin/sh -c "/usr/sbin/dmidecode -s system-serial-number | /bin/egrep -v '^#' | /usr/sbin/linuxpba"
+StandardOutput=journal+console
+StandardError=journal+console
 
 [Install]
 WantedBy=basic.target local-fs.target

--- a/ManualBuild.sh
+++ b/ManualBuild.sh
@@ -1,53 +1,73 @@
 #!/bin/bash
 
-WORKSPACE=`pwd`
+set -euxo pipefail
+WORKSPACE=$(pwd)
 
-WORKDIRS="${WORKSPACE}/LinuxPBA ${WORKSPACE}/linux/CLI"
+WORKDIRS=("${WORKSPACE}/LinuxPBA" "${WORKSPACE}/linux/CLI")
 VERSION="Release_x86_64"
 OPAL_UNIT=sed-opal.service
 EXEDIR=/usr/sbin
+MAN_PAGE=sedutil-cli.8
+MAN_DIR=/usr/share/man/man8
 USR_SYSTEMD=/etc/systemd/system
 PKGDIR=debian
 
-set -ex
+export LDFLAGS=-static
 
+COMMIT=$(git rev-parse --short HEAD)
+
+PKG_VERSION=$(git tag --sort=taggerdate | tail -n1)+g"$COMMIT"
 #FIXME Cleanup
-for WRKDIR in $WORKDIRS
+for WRKDIR in "${WORKDIRS[@]}"
 do
-	( cd $WRKDIR; make CONF=${VERSION} clean ) || /bin/true
+	make -j8 -C "$WRKDIR" CONF="${VERSION}" clean
 done
 
-rm -rf *.deb
-rm -rf ${PKGDIR} || /bin/true
+rm -rf "*.deb"
+sudo rm -rf "${PKGDIR}"
 
-mkdir ${PKGDIR}
-mkdir -p ${PKGDIR}/${EXEDIR} || /bin/true
-mkdir -p ${PKGDIR}/${USR_SYSTEMD} || /bin/true
+mkdir "${PKGDIR}"
+mkdir -p "${PKGDIR}/${EXEDIR}"
+mkdir -p "${PKGDIR}/${USR_SYSTEMD}"
+mkdir -p "${PKGDIR}/${MAN_DIR}"
 
-cp -rp DEBIAN ${PKGDIR}
+cp -rp DEBIAN "${PKGDIR}"
+cat > "$PKGDIR/DEBIAN/control" <<EOF
+Package: sedutil
+Section: utils
+Version: $PKG_VERSION
+Architecture: amd64
+Maintainer: ops-team@kentik.com
+Homepage: https://github.com/kentik/sedutil
+Description: Forked and locally-modified DTA sedutil-cli package. Statically compiled, should be good for all modern distros. Built from commit $COMMIT.
+EOF
 
-for DIR in $WORKDIRS
+for DIR in "${WORKDIRS[@]}"
 do
-  ( cd $DIR ; make CONF=${VERSION} clean ; make CONF=${VERSION} ) 2>&1 | tee logfile.txt
+  ( make -j8 -C "$DIR" CONF="${VERSION}" clean ; make -j8 -C "$DIR" CONF="${VERSION}" ) 2>&1 | tee logfile.txt
 done
 
-for DIR in $WORKDIRS
+for DIR in "${WORKDIRS[@]}"
 do
-  cp ${DIR}/dist/${VERSION}/GNU-Linux/* ${PKGDIR}/${EXEDIR}
+  cp "${DIR}/dist/${VERSION}/GNU-Linux/"* "${PKGDIR}/${EXEDIR}"
 done
 
-cp Contrib/${OPAL_UNIT} ${PKGDIR}/${USR_SYSTEMD}
-chmod 0644 ${PKGDIR}/${USR_SYSTEMD}/${OPAL_UNIT}
+cp docs/"${MAN_PAGE}" "${PKGDIR}/${MAN_DIR}"
+gzip -9 "${PKGDIR}/${MAN_DIR}/${MAN_PAGE}"
+cp "Contrib/${OPAL_UNIT}" "${PKGDIR}/${USR_SYSTEMD}"
+chmod 0644 "${PKGDIR}/${USR_SYSTEMD}/${OPAL_UNIT}"
 
-sudo find ${PKGDIR} -exec chown 0:0 {} \;
+sudo find "${PKGDIR}" -execdir chown 0:0 '{}' +;
 
-dpkg-deb --build ${PKGDIR} 
+dpkg-deb --build "${PKGDIR}"
 
-set -- `dpkg-deb --info debian.deb  | egrep 'Package|Version|Architecture' | tr -d ' ' | tr ':' '='`
-for var
+pkg_ver_arch=$(dpkg-deb --info debian.deb  \
+		   | grep -E 'Package|Version|Architecture' \
+		   | tr -d ' ' \
+		   | tr ':' '=')
+for var in "${pkg_ver_arch[@]}"
 do
-  eval $var
+  eval "$var"
 done
 
-mv debian.deb ${Package}_${Version}_${Architecture}.deb
-
+mv debian.deb "${Package}_${Version}_${Architecture}.deb"


### PR DESCRIPTION
* write sedutil info to console instead of writing to /tmpfs
  info like that should be printed during boot

* shellcheck fixes in ManualBuild.sh

* Generate package version number based on the last git tag + commit

* Compile the packages statically

* Package manpage as well