### PR TITLE
Fix building package

### DIFF
--- a/project.yml
+++ b/project.yml
@@ -1,4 +1,5 @@
 name: sedutil
+description: Software to manage SED - self-encrypting drives.
 version: TAG
 target:
   # we want to upload original deb created by ManualBuild.sh to artifactory so we are moving it to `artifacts` directory, and the rest will be done at kbt level


### PR DESCRIPTION
This package could not be installed because of the following error 

> dpkg: error processing archive /var/cache/apt/archives/kentik-sedutil_1.15.1-2.260505.140.078b3141ca.master_amd64.deb (--unpack):
 parsing file '/var/lib/dpkg/tmp.ci/control' near line 10 package 'kentik-sedutil':
 end of file before value of field 'Description' (missing final newline)
Errors were encountered while processing:
 /var/cache/apt/archives/kentik-sedutil_1.15.1-2.260505.140.078b3141ca.master_amd64.deb

If we look into the control file we get this:
>Package: kentik-sedutil
Version: 1.15.1-2.260505.140.078b3141ca.master
License: unknown
Vendor: Kentik
Architecture: amd64
Maintainer: builds@kentik.com
Installed-Size: 0
Section: internal
Priority: optional
Homepage: http://example.com/no-uri-given
Description: 

Adding a description should fix it.